### PR TITLE
Site Update - Update to use HashRouter instead of BrowserRouter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import './App.css'
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
 import Home from './components/Home'
 import NotFound from './components/NotFound';
 import ProjectsList from './components/ProjectsList'
@@ -7,14 +7,14 @@ import ProjectItem from './components/ProjectItem';
 
 function App() {
   return (
-      <BrowserRouter basename={import.meta.env.BASE_URL}>
+      <HashRouter>
         <Routes>
           <Route path='/' element={<Home />} />
           <Route path='/projects' element={<ProjectsList />} />
           <Route path='/projects/:project' element={<ProjectItem />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
-      </BrowserRouter>
+      </HashRouter>
   )
 }
 


### PR DESCRIPTION
- Update to use `HashRouter` instead of `BrowserRouter` so routing happens entirely in the browser (using `#` in the URL), preventing GitHub Pages from failing to load paths like `/projects`